### PR TITLE
PMXRD-205 ggplot2 deprecated args

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggcertara
 Type: Package
-Version: 0.4.1
-Date: 2020-11-17
+Version: 0.5.0
+Date: 2026-02-12
 Title: A ggplot2 theme for Certara CSC-iDD
 Authors@R: c(
     person("James", "Craig", role=c("aut", "cre"), email="james.craig@certara.com"),
@@ -15,7 +15,7 @@ BugReports: https://github/certara/ggcertara/issues
 License: GPL-3
 Depends: R (>= 2.10)
 Imports:
-    ggplot2 (>= 3.0.0),
+    ggplot2 (>= 3.4.0),
     ggforce,
     scales,
     rlang,

--- a/R/gof.R
+++ b/R/gof.R
@@ -121,8 +121,8 @@ gof_residual <- function(data, x, y, labels=gof_labels(), baseplot=gof_baseplot,
     aes(x={{ x }}, y={{ y }}) +
     labs(x=xlb, y=ylb) +
     coord_symm_y() +
-    geom_hline(yintercept=0, color="black", linetype="dashed", size=0.8) +
-    theme(panel.grid.major.y=element_line(colour="grey80", size=0.3))
+    geom_hline(yintercept=0, color="black", linetype="dashed", linewidth=0.8) +
+    theme(panel.grid.major.y=element_line(colour="grey80", linewidth=0.3))
   if (isTRUE(log_x)) {
     g <- log_x(g)
   }
@@ -138,8 +138,8 @@ gof_absresidual <- function(data, x, y, labels=gof_labels(), baseplot=gof_basepl
     aes(x={{ x }}, y=abs({{ y }})) +
     labs(x=xlb, y=sprintf("|%s|", ylb)) +
     expand_limits(y=0) +
-    #geom_hline(yintercept=0, color="black", linetype="dashed", size=0.8) +
-    theme(panel.grid.major.y=element_line(colour="grey80", size=0.3))
+    #geom_hline(yintercept=0, color="black", linetype="dashed", linewidth=0.8) +
+    theme(panel.grid.major.y=element_line(colour="grey80", linewidth=0.3))
   if (isTRUE(log_x)) {
     g <- log_x(g)
   }
@@ -167,7 +167,7 @@ gof_identity <- function(data, x, y, labels=gof_labels(), baseplot=gof_baseplot,
     aes(x={{ x }}, y={{ y }}) +
     labs(x=xlb, y=ylb) +
     coord_symm_xy() +
-    geom_abline(slope=1, color="black", linetype="dashed", size=0.8)
+    geom_abline(slope=1, color="black", linetype="dashed", linewidth=0.8)
   if (isTRUE(log_xy)) {
     g <- log_xy(g)
   }
@@ -268,14 +268,14 @@ gof_histogram <- function(data, x, bins=20, labels=gof_labels(), symm_x=if (isTR
     } else {
       g <- log_x(g)
     }
-    g <- g + stat_function(fun=stats::dlnorm, color="black", linetype="dashed", size=0.8)
+    g <- g + stat_function(fun=stats::dlnorm, color="black", linetype="dashed", linewidth=0.8)
   } else {
     if (!is.null(symm_x))  {
       g <- g +
         scale_x_continuous(limits=function(x) symm_x + c(-1, 1)*max(abs(x - symm_x), na.rm=T)) +
         geom_vline(xintercept=symm_x, col="gray50")
     }
-    g <- g + stat_function(fun=stats::dnorm, color="black", linetype="dashed", size=0.8)
+    g <- g + stat_function(fun=stats::dnorm, color="black", linetype="dashed", linewidth=0.8)
   }
   g
 }
@@ -300,7 +300,7 @@ gof_qqplot <- function(data, x, labels=gof_labels()) {
     coord_symm_xy() +
     stat_qq(geom="point_c") +
     stat_qq_line(geom="fitline_c") +
-    geom_abline(slope=1, color="black", linetype="dashed", size=0.8) +
+    geom_abline(slope=1, color="black", linetype="dashed", linewidth=0.8) +
     theme_certara(base_size=11) +
     theme(aspect.ratio=1)
   g
@@ -758,7 +758,7 @@ indiv_plot <- function(data,
           linetype = 'ipred',
           colour = 'ipred'
         ),
-        size = line_size,
+        linewidth = line_size,
         show.legend = TRUE
       ) +
       ggplot2::geom_line(
@@ -773,7 +773,7 @@ indiv_plot <- function(data,
           linetype = 'pred',
           colour = 'pred'
         ),
-        size = line_size,
+        linewidth = line_size,
         show.legend = TRUE
       ) +
       ggplot2::scale_linetype_manual(
@@ -1012,7 +1012,7 @@ indiv_plot <- function(data,
           linetype = 'ipred',
           colour = 'ipred'
         ),
-        size = line_size,
+        linewidth = line_size,
         show.legend = FALSE
       ) +
       ggplot2::geom_line(
@@ -1027,7 +1027,7 @@ indiv_plot <- function(data,
           linetype = 'pred',
           colour = 'pred'
         ),
-        size = line_size,
+        linewidth = line_size,
         show.legend = FALSE
       ) +
 

--- a/R/theme_certara.R
+++ b/R/theme_certara.R
@@ -68,14 +68,14 @@ theme_certara <- function(base_size=11, base_family="",
     theme_c <- theme(
         line=element_line(
             colour="black",
-            size=base_line_size, 
+            linewidth=base_line_size, 
             linetype=1,
             lineend="butt"),
 
         rect=element_rect(
             fill="white", 
             colour="black",
-            size=base_rect_size,
+            linewidth=base_rect_size,
             linetype=1), 
 
         text=element_text(
@@ -116,7 +116,7 @@ theme_certara <- function(base_size=11, base_family="",
             margin=margin(l=0.8*half_line/2),
             hjust=0.5),
         
-        axis.ticks=element_line(colour="grey40", size=0.3), 
+        axis.ticks=element_line(colour="grey40", linewidth=0.3), 
 
         axis.ticks.length=unit(half_line, "pt"),
         axis.ticks.length.x=unit(half_line, "pt"),
@@ -165,13 +165,9 @@ theme_certara <- function(base_size=11, base_family="",
             size=rel(0.9),
             margin=margin(r=2*half_line, unit="pt")),
 
-        legend.text.align=NULL,
-
         legend.title=element_text(
             size=rel(0.9),
             hjust=0), 
-
-        legend.title.align=NULL,
         
         legend.position="bottom", 
         legend.direction="horizontal",
@@ -189,7 +185,7 @@ theme_certara <- function(base_size=11, base_family="",
         panel.border=element_rect(
             fill=NA,
             colour="grey60",
-            size=0.3),
+            linewidth=0.3),
 
         panel.grid=element_blank(), 
         panel.grid.major=element_blank(), 
@@ -251,12 +247,12 @@ theme_certara <- function(base_size=11, base_family="",
 
     if (grid == "horizontal") {
         theme_c <- theme_c %+replace% theme(
-            panel.grid.major.y=element_line(colour="grey90", size=0.3), 
-            panel.grid.minor.y=element_line(colour="grey90", size=0.3))
+            panel.grid.major.y=element_line(colour="grey90", linewidth=0.3), 
+            panel.grid.minor.y=element_line(colour="grey90", linewidth=0.3))
     } else if (grid == "both") {
         theme_c <- theme_c %+replace% theme(
-            panel.grid.major=element_line(colour="grey90", size=0.3), 
-            panel.grid.minor=element_line(colour="grey90", size=0.3))
+            panel.grid.major=element_line(colour="grey90", linewidth=0.3), 
+            panel.grid.minor=element_line(colour="grey90", linewidth=0.3))
     }
 
     theme_c
@@ -369,7 +365,6 @@ certara_palfn <- function(start=1, select=NULL, permute=NULL, discard=NULL) {
 scale_colour_certara <- function(...) {
     ggplot2::discrete_scale(
         aesthetics="colour",
-        scale_name="certara",
         palette=certara_palfn(...))
 }
 
@@ -382,7 +377,6 @@ scale_color_certara <- scale_colour_certara
 scale_fill_certara <- function(...) {
     ggplot2::discrete_scale(
         aesthetics="fill",
-        scale_name="certara",
         palette=certara_palfn(...))
 }
 
@@ -391,7 +385,6 @@ scale_fill_certara <- function(...) {
 scale_colour_certara_c <- function(..., guide="colourbar") {
     ggplot2::continuous_scale(
         aesthetics="colour",
-        scale_name="certara_c",
         palette=scales::gradient_n_pal(certara_pal()[1:3]),
         guide=guide)
 }
@@ -401,7 +394,6 @@ scale_colour_certara_c <- function(..., guide="colourbar") {
 scale_fill_certara_c <- function(..., guide="colourbar") {
     ggplot2::continuous_scale(
         aesthetics="fill",
-        scale_name="certara_c",
         palette=scales::gradient_n_pal(certara_pal()[1:3]),
         guide=guide)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -179,35 +179,37 @@ GeomFitlineC <- ggproto("GeomFitlineC", GeomLine,
 
                         default_aes = aes(
                           fitcolour = "#ee3124", fitsize = 1,
-                          fitalpha = NA, fitlinetype = 1
+                          fitalpha = NA, fitlinetype = 1,
+                          colour = "#ee3124", linewidth = 1,
+                          alpha = NA, linetype = 1
                         ),
 
                         handle_na = function(self, data, params) {
-                          data2 <- data[!(names(data) %in% c("colour", "color", "size", "alpha", "linetype"))]
+                          data2 <- data[!(names(data) %in% c("colour", "color", "size", "linewidth", "alpha", "linetype"))]
                           nm <- names(data2)
                           nm <- ifelse(nm=="fitcolour",   "colour",   nm)
                           nm <- ifelse(nm=="fitcolor",    "color",    nm)
-                          nm <- ifelse(nm=="fitsize",     "size",     nm)
+                          nm <- ifelse(nm=="fitsize",     "linewidth",nm)
                           nm <- ifelse(nm=="fitalpha",    "alpha",    nm)
                           nm <- ifelse(nm=="fitlinetype", "linetype", nm)
                           names(data2) <- nm
                           data3 <- self$super()$handle_na(data=data2, params=params)
                           nm <- names(data3)
-                          nm <- ifelse(nm=="colour",   "fitcolour",   nm)
-                          nm <- ifelse(nm=="color",    "fitcolor",    nm)
-                          nm <- ifelse(nm=="size",     "fitsize",     nm)
-                          nm <- ifelse(nm=="alpha",    "fitalpha",    nm)
-                          nm <- ifelse(nm=="linetype", "fitlinetype", nm)
+                          nm <- ifelse(nm=="colour",    "fitcolour",   nm)
+                          nm <- ifelse(nm=="color",     "fitcolor",    nm)
+                          nm <- ifelse(nm=="linewidth", "fitsize",     nm)
+                          nm <- ifelse(nm=="alpha",     "fitalpha",    nm)
+                          nm <- ifelse(nm=="linetype",  "fitlinetype", nm)
                           names(data3) <- nm
                           data3
                         },
 
                         draw_panel = function(self, data, ...) {
-                          data2 <- data[!(names(data) %in% c("colour", "color", "size", "alpha", "linetype"))]
+                          data2 <- data[!(names(data) %in% c("colour", "color", "size", "linewidth", "alpha", "linetype"))]
                           nm <- names(data2)
                           nm <- ifelse(nm=="fitcolour",   "colour",   nm)
                           nm <- ifelse(nm=="fitcolor",    "color",    nm)
-                          nm <- ifelse(nm=="fitsize",     "size",     nm)
+                          nm <- ifelse(nm=="fitsize",     "linewidth",nm)
                           nm <- ifelse(nm=="fitalpha",    "alpha",    nm)
                           nm <- ifelse(nm=="fitlinetype", "linetype", nm)
                           names(data2) <- nm
@@ -256,6 +258,9 @@ stat_loess_c <- geom_loess_c
 #' @export
 StatLoessC <- ggproto("StatLoessC", Stat,
                       required_aes = c("x", "y"),
+
+                      dropped_aes = c("colour", "color", "shape", "size",
+                                       "fill", "alpha", "linetype", "linewidth"),
 
                       compute_group = function(data, scales, span = 2/3, degree = 1, family = "symmetric", na.rm = FALSE) {
                         tryCatch({
@@ -399,5 +404,5 @@ log_xy <- function(g, limits=NULL) {
       labels = scales::trans_format("log10", scales::math_format(10^.x)),
       limits = limits
     ) +
-    annotation_logticks(sides="bl", size=0.3)
+    annotation_logticks(sides="bl", linewidth=0.3)
 }

--- a/inst/colorexplorer-app/app.R
+++ b/inst/colorexplorer-app/app.R
@@ -270,17 +270,17 @@ shinyApp(
           legend.position="bottom", 
           axis.text=element_text(color="gray40"),
           axis.title=element_text(color="gray40"),
-          axis.ticks=element_line(color="grey40", size=0.3), 
-          panel.border=element_rect(fill=NA, color="grey60", size=0.3),
-          panel.grid.major.y=element_line(colour="grey90", size=0.3), 
-          panel.grid.minor.y=element_line(colour="grey90", size=0.3),
+          axis.ticks=element_line(color="grey40", linewidth=0.3), 
+          panel.border=element_rect(fill=NA, color="grey60", linewidth=0.3),
+          panel.grid.major.y=element_line(colour="grey90", linewidth=0.3), 
+          panel.grid.minor.y=element_line(colour="grey90", linewidth=0.3),
           panel.grid.major.x=element_blank(), 
           panel.grid.minor.x=element_blank())
 
       g2 <- ggplot(dat1(), aes(x=x, y=y, color=set, fill=set)) +
         labs(x="X-Axis Label [units]", y="Y-Axis Label [units]", color=NULL, fill=NULL) +
         geom_point(size=2, alpha=0.3) +
-        geom_smooth(method="lm", formula=y~x, size=0.8, se=FALSE) +
+        geom_smooth(method="lm", formula=y~x, linewidth=0.8, se=FALSE) +
         scale_color_manual(values=palr()) +
         scale_fill_manual(values=palr()) +
         #theme_bw(base_size=11, base_family="Arial Narrow") +
@@ -289,10 +289,10 @@ shinyApp(
           legend.position="bottom", 
           axis.text=element_text(color="gray40"),
           axis.title=element_text(color="gray40"),
-          axis.ticks=element_line(color="grey40", size=0.3), 
-          panel.border=element_rect(fill=NA, color="grey60", size=0.3),
-          panel.grid.major=element_line(colour="grey90", size=0.3), 
-          panel.grid.minor=element_line(colour="grey90", size=0.3))
+          axis.ticks=element_line(color="grey40", linewidth=0.3), 
+          panel.border=element_rect(fill=NA, color="grey60", linewidth=0.3),
+          panel.grid.major=element_line(colour="grey90", linewidth=0.3), 
+          panel.grid.minor=element_line(colour="grey90", linewidth=0.3))
 
       if (input$colorblind) {
         if (!requireNamespace("colorblindr", quietly = TRUE)) {

--- a/man/certara_geom.Rd
+++ b/man/certara_geom.Rd
@@ -86,7 +86,7 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this layer.
 When using a \verb{geom_*()} function to construct a layer, the \code{stat}
-argument can be used the override the default coupling between geoms and
+argument can be used to override the default coupling between geoms and
 stats. The \code{stat} argument accepts the following:
 \itemize{
 \item A \code{Stat} ggproto subclass, for example \code{StatCount}.
@@ -145,12 +145,14 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{NA}, the default, includes if any aesthetics are mapped.
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
-display.}
+display. To include legend keys for all levels, even
+when no data exists, use \code{TRUE}.  If \code{NA}, all levels are shown in legend,
+but unobserved levels are omitted.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 
 \item{orientation}{The orientation of the layer. The default (\code{NA})
 automatically determines the orientation from the aesthetic mapping. In the

--- a/man/coord_symm_x.Rd
+++ b/man/coord_symm_x.Rd
@@ -13,7 +13,11 @@ coord_symm_x(xlim = NULL, ylim = NULL, expand = TRUE, clip = "on")
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}.
+Giving a logical vector will separately control the expansion for the four
+directions (top, left, bottom and right). The \code{expand} argument will be
+recycled to length 4 if necessary. Alternatively, can be a named logical
+vector to control a single direction, e.g. \code{expand = c(bottom = FALSE)}.}
 
 \item{clip}{Should drawing be clipped to the extent of the plot panel? A
 setting of \code{"on"} (the default) means yes, and a setting of \code{"off"}

--- a/man/coord_symm_xy.Rd
+++ b/man/coord_symm_xy.Rd
@@ -13,7 +13,11 @@ coord_symm_xy(xlim = NULL, ylim = NULL, expand = TRUE, clip = "on")
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}.
+Giving a logical vector will separately control the expansion for the four
+directions (top, left, bottom and right). The \code{expand} argument will be
+recycled to length 4 if necessary. Alternatively, can be a named logical
+vector to control a single direction, e.g. \code{expand = c(bottom = FALSE)}.}
 
 \item{clip}{Should drawing be clipped to the extent of the plot panel? A
 setting of \code{"on"} (the default) means yes, and a setting of \code{"off"}

--- a/man/coord_symm_y.Rd
+++ b/man/coord_symm_y.Rd
@@ -13,7 +13,11 @@ coord_symm_y(xlim = NULL, ylim = NULL, expand = TRUE, clip = "on")
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
-limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
+limits are taken exactly from the data or \code{xlim}/\code{ylim}.
+Giving a logical vector will separately control the expansion for the four
+directions (top, left, bottom and right). The \code{expand} argument will be
+recycled to length 4 if necessary. Alternatively, can be a named logical
+vector to control a single direction, e.g. \code{expand = c(bottom = FALSE)}.}
 
 \item{clip}{Should drawing be clipped to the extent of the plot panel? A
 setting of \code{"on"} (the default) means yes, and a setting of \code{"off"}

--- a/man/indiv_plot.Rd
+++ b/man/indiv_plot.Rd
@@ -50,6 +50,10 @@ indiv_plot(
 
 \item{ip_nrow}{Number of rows per plot. Default is 4. Adjust similarly to \code{ip_ncol} for pagination issues.}
 
+\item{scale_facet}{Character string specifying the scale type for faceted plots. One of "fixed", "free", "free_x", or "free_y". Default is "fixed".}
+
+\item{labelfacet}{Character string specifying the labeller function for faceted plots. One of "label_value", "label_both", "label_context", or "label_parsed". Default is "label_value".}
+
 \item{strati1}{The variable used to stratify the plots. Default is "id".}
 
 \item{strati2}{An optional variable for an additional layer of stratification. Default is NULL.}

--- a/tests/testthat/test-deprecations.R
+++ b/tests/testthat/test-deprecations.R
@@ -1,0 +1,129 @@
+library(testthat)
+library(ggcertara)
+
+# Helper: fully render a ggplot object to trigger any render-time warnings
+render_plot <- function(p) {
+  grob <- ggplot2::ggplotGrob(p)
+  invisible(grob)
+}
+
+# --- Theme functions ---
+test_that("theme_certara() produces no deprecation warnings", {
+  expect_no_warning(theme_certara())
+  expect_no_warning(theme_certara_grid())
+  expect_no_warning(theme_certara_hgrid())
+})
+
+# --- Scale functions ---
+test_that("scale functions produce no deprecation warnings", {
+  dat <- data.frame(x = 1:5, y = 1:5, g = factor(letters[1:5]))
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y, colour = g)) +
+      geom_point() +
+      scale_color_certara()
+    render_plot(p)
+  })
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y, fill = g)) +
+      geom_col() +
+      scale_fill_certara()
+    render_plot(p)
+  })
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y, colour = y)) +
+      geom_point() +
+      scale_colour_certara_c()
+    render_plot(p)
+  })
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y, fill = y)) +
+      geom_tile() +
+      scale_fill_certara_c()
+    render_plot(p)
+  })
+})
+
+# --- GOF plots with line-based geoms ---
+test_that("GOF residual/identity plots produce no deprecation warnings", {
+  data(nmtable)
+  colnames(nmtable) <- tolower(colnames(nmtable))
+
+  # gof_residual uses geom_hline + element_line
+  expect_no_warning({
+    p <- gof_cwres_vs_pred(nmtable)
+    render_plot(p)
+  })
+
+  # gof_identity uses geom_abline
+  expect_no_warning({
+    p <- gof_dv_vs_pred(nmtable)
+    render_plot(p)
+  })
+
+  # gof_identity with log scale uses annotation_logticks
+  # Muffle expected data warnings (log-10, non-finite rows); deprecation warnings still propagate
+  expect_no_warning({
+    withCallingHandlers({
+      p <- gof_dv_vs_pred(nmtable, log_xy = TRUE)
+      render_plot(p)
+    }, warning = function(w) {
+      if (!grepl("deprecated|lifecycle", conditionMessage(w), ignore.case = TRUE))
+        invokeRestart("muffleWarning")
+    })
+  })
+})
+
+test_that("GOF histogram plots produce no deprecation warnings", {
+  data(nmtable)
+  colnames(nmtable) <- tolower(colnames(nmtable))
+
+  # gof_histogram uses stat_function
+  expect_no_warning({
+    p <- gof_cwres_histogram(nmtable)
+    render_plot(p)
+  })
+})
+
+# --- Custom geoms ---
+test_that("geom_fitline_c and geom_loess_c produce no deprecation warnings", {
+  dat <- data.frame(x = 1:20, y = cumsum(rnorm(20)))
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y)) +
+      geom_point_c() +
+      geom_fitline_c() +
+      theme_certara()
+    render_plot(p)
+  })
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y)) +
+      geom_point_c() +
+      geom_loess_c() +
+      theme_certara()
+    render_plot(p)
+  })
+})
+
+# --- Theme grid variants ---
+test_that("theme grid variants produce no deprecation warnings when rendered", {
+  dat <- data.frame(x = 1:10, y = rnorm(10))
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y)) +
+      geom_point() +
+      theme_certara_grid()
+    render_plot(p)
+  })
+
+  expect_no_warning({
+    p <- ggplot(dat, aes(x, y)) +
+      geom_point() +
+      theme_certara_hgrid()
+    render_plot(p)
+  })
+})

--- a/vignettes/ggcertara-gof.Rmd
+++ b/vignettes/ggcertara-gof.Rmd
@@ -435,7 +435,7 @@ As another example, we can add a blue linear regression line in addition to the 
 
 ```{r message=F,fig.width=6, fig.height=3, out.width="60%"}
 gof(dat, panels=8:9) &
-  geom_smooth(method="lm", color=certara_pal()[1], se=F, size=1)
+  geom_smooth(method="lm", color=certara_pal()[1], se=F, linewidth=1)
 ```
 
 # R session information


### PR DESCRIPTION
Replace all deprecated ggplot2 arguments across the package: size to linewidth in line/rect elements and line-based geoms (ggplot2 3.4.0), and remove deprecated scale_name and legend.*.align arguments (ggplot2 3.5.0). Update the custom GeomFitlineC geom to use the new linewidth aesthetic when delegating to GeomLine, and add dropped_aes to StatLoessC to suppress spurious warnings. Bump package version to 0.5.0, ggplot2 dependency to >= 3.4.0, and add regression tests.